### PR TITLE
fix: find bins in /usr/bin first

### DIFF
--- a/9.3/Dockerfile
+++ b/9.3/Dockerfile
@@ -21,4 +21,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
 
 RUN echo "plperl.on_init = 'use utf8; use re; package utf8; require \"utf8_heavy.pl\";'" >> /usr/share/postgresql/postgresql.conf.sample
 
+ENV PATH /usr/bin:$PATH
+
 COPY initdb.sh /docker-entrypoint-initdb.d/

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -21,4 +21,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
 
 RUN echo "plperl.on_init = 'use utf8; use re; package utf8; require \"utf8_heavy.pl\";'" >> /usr/share/postgresql/postgresql.conf.sample
 
+ENV PATH /usr/bin:$PATH
+
 COPY initdb.sh /docker-entrypoint-initdb.d/

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -21,4 +21,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
 
 RUN echo "plperl.on_init = 'use utf8; use re; package utf8; require \"utf8_heavy.pl\";'" >> /usr/share/postgresql/postgresql.conf.sample
 
+ENV PATH /usr/bin:$PATH
+
 COPY initdb.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Проблема в том, что при запуске psql используется бинарник /usr/lib/postgresql/9.6/bin/psql, который собран без подержки readline по-умолчанию,
в итоге в psql у нас нет возможности вводить русские буквы и нет автокомплита по табуляции и вообще нет поддержки readline :)
Проблема решается запуском psql через скрипт /usr/bin/psql, который ставится вместе с postgresql-client. Скрипт запускает бинарник с предзагрузкой libreadline
через переменную окружения LD_PRELOAD. Источник http://blog.endpoint.com/2011/08/debian-postgres-readline-psql-problem.html
Вот место в скрипте /usr/bin/psql где подцепляется libreadline вместо libedit:
```
# libreadline is a lot better than libedit, so prefer that
if ( eq 'psql' and not ::rpm) {
    my @readlines;
    # non-multiarch path
    @readlines = sort(</lib/libreadline.so.?>);

    unless (@readlines) {
        # get multiarch dir for our architecture
        if (open PS, '-|', '/usr/bin/ldd', ) {
            my ;
            read PS, , 10000;
            close PS;
                # already linked against libreadline
                @readlines = ();
            }
            else
            {

                @readlines = sort(</libreadline.so.?>);
            }
        }
    }
```