### PR TITLE
chore: upgrade pg_jobmon to 1.3

### DIFF
--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -28,10 +28,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
 
 RUN echo "plperl.on_init = 'use utf8; use re; package utf8; require \"utf8_heavy.pl\";'" >> /usr/share/postgresql/postgresql.conf.sample
 
-RUN wget https://github.com/omniti-labs/pg_jobmon/archive/v1.2.0.zip \
-    && unzip v1.2.0.zip \
-    && make -C pg_jobmon-1.2.0 \
-    && make NO_BGW=1 install -C pg_jobmon-1.2.0
+RUN wget https://github.com/omniti-labs/pg_jobmon/archive/v1.3.3.zip \
+    && unzip v1.3.3.zip \
+    && make -C pg_jobmon-1.3.3 \
+    && make NO_BGW=1 install -C pg_jobmon-1.3.3
 
 RUN wget https://github.com/keithf4/pg_partman/archive/v1.8.0.zip \
     && unzip v1.8.0.zip \


### PR DESCRIPTION
Надо, тк поменялась структура таблиц на тестовом после обновления 1.2 > 1.3
https://github.com/omniti-labs/pg_jobmon/blob/59fdba7f6599036bbd21d5854003cd928734ee7d/updates/pg_jobmon--1.2.0--1.3.0.sql#L5